### PR TITLE
Improve `net` extension performance

### DIFF
--- a/samples/networkClient.bf
+++ b/samples/networkClient.bf
@@ -1,13 +1,14 @@
 tl:net
 
-# Please starts a netcat (nc) server on port 24001 now
+# Please starts a netcat (nc) server on port 42001 now
 
 -*  # Set timeout to 25 seconds and a half
-++@ # Set port to 24001
+++@ # Set port to 42001
 
 # Start an infinite loop
 # Write something on your terminal and press enter
 [>
     , # Read user input
-    ^ # Send user input to localhost port 24001
+    ^ # Queues the user input to be sent to localhost port 42001
+    ; # Flushes the send cache
 <]

--- a/samples/networkServer.bf
+++ b/samples/networkServer.bf
@@ -1,14 +1,12 @@
 tl:net
 
-# Send bytes to local port 24002 using netcat (nc)
-# Note that this accepts only 1 byte at the time
-# This limitation might be fixed in the future by optimizing the network server
+# Send bytes to local port 42002 using netcat (nc)
 
 -*  # Set timeout to 25 seconds and a half
-+++@ # Set port to 24002
++++@ # Set port to 42002
 
 # Start an infinite loop
 [>
-    ? # Receive on all IPv4 port 24002 and write to memory
+    ? # Receive on all IPv4 port 42002 and write to memory
     . # Print to stdout
 <]

--- a/src/extension_network.go
+++ b/src/extension_network.go
@@ -1,88 +1,292 @@
 package interpreter
 
 import (
+	"errors"
 	"net"
+	"runtime"
 	"strconv"
+	"sync/atomic"
 	"time"
+)
+
+const (
+	// The target address
+	NetTargetAddr = "127.0.0.1:"
+	// The listening address
+	NetListenAddr = "0.0.0.0:"
+	// Long timeout used for timeout = 0
+	// If the timeout is set to this all ops must retry until success
+	NetLongTimeout = time.Minute
+)
+
+const (
+	// Idling
+	netStateIdle uint8 = 0
+	// Listening for incoming connection
+	netStateListening uint8 = 1
+	// We have an active connection
+	netStateConnected uint8 = 2
 )
 
 // The network extension
 type Network struct {
+	// Lock on this data structure
+	isLocked atomic.Bool
+	// Internal state
+	state uint8
 	// Universal timeout
 	timeout time.Duration
-	// Port in the ":42000" format
+	// Port in the "42000" format
 	port string
+	// Cached listener
+	listener net.Listener
+	// Cached connection
+	conn net.Conn
+	// Send Cache
+	sendCache []byte
+}
+
+// Lock
+func (n *Network) lock(lowPriority bool) {
+	for !n.isLocked.CompareAndSwap(false, true) {
+		if lowPriority {
+			runtime.Gosched()
+		}
+	}
+}
+
+// Unlock
+func (n *Network) unlock() {
+	n.isLocked.Store(false)
+}
+
+// Closes all connections and resets the cache
+// clearCache controls if the cache is reset or not
+// NOTE: Requires the lock to be held by the current process
+func (n *Network) reset(clearCache bool) {
+	if n.state == netStateListening {
+		n.listener.Close()
+	}
+	if n.state == netStateConnected {
+		n.conn.Close()
+	}
+	if clearCache {
+		n.sendCache = []byte{}
+	}
+	n.state = netStateIdle
+}
+
+// Sets up the listener
+// Returns true on success, false otherwise
+// NOTE: Requires the lock to be held by the current process
+func (n *Network) startListening() bool {
+	// Init
+	n.reset(true)
+	// Setup listener
+	listener, err := net.Listen("tcp4", NetListenAddr+n.port)
+	if err != nil {
+		return false
+	}
+	// Accept connections
+	cAccepting := make(chan bool)
+	go func(listener net.Listener) {
+		cAccepting <- true
+		conn, err := listener.Accept()
+		if errors.Is(err, net.ErrClosed) {
+			// This listener was closed
+			return
+		}
+		listener.Close()
+		if err == nil {
+			n.lock(false)
+			n.state = netStateConnected
+			n.conn = conn
+			n.listener = nil
+			n.unlock()
+		}
+	}(listener)
+	// If ready to accept, finalize setup and terminate
+	<-cAccepting
+	n.listener = listener
+	n.state = netStateListening
+	return true
+}
+
+// Setup a connection to the current target
+// Returns true if successful, false otherwise
+// NOTE: Requires the lock to be held by the current process
+func (n *Network) setupConnection() bool {
+	// Init (but don't reset the send cache)
+	n.reset(false)
+	// Connect
+	conn, err := net.DialTimeout("tcp4", NetTargetAddr+n.port, n.timeout)
+	if err != nil {
+		return false
+	}
+	n.state = netStateConnected
+	n.conn = conn
+	return true
 }
 
 // Sets the timeout corresponding to the given byte
 // Formula: timeout = 0.1 second * b
 func (n *Network) SetTimeout(b byte) {
-	n.timeout = (time.Second / 10) * time.Duration(b)
+	n.lock(false)
+	if b == 0 {
+		// Special case: if timeout is 0, receive/send is blocking until success
+		n.timeout = NetLongTimeout
+		return
+	}
+	n.timeout = time.Duration(b) * (time.Second / 10)
+	n.unlock()
 }
 
 // Sets the port corresponding to the given byte
 // Formula: port = 24000 + b
 func (n *Network) SetPort(b byte) {
+	// Get lock
+	n.lock(false)
+	// Update port
 	n.port = byteToPort(b)
+	// Reset
+	n.reset(true)
+	// Unlock
+	n.unlock()
 }
 
-// Attempts to send a byte of data to localhost at the saved port
-// Returns true if success, false otherwise
-func (n *Network) Send(b byte) bool {
-	conn, err := net.DialTimeout("tcp4", "127.0.0.1:"+n.port, n.timeout)
-	if err != nil {
-		return false
+// Send queue over the network
+// Also removes the data from send cache if successful
+// Assumes lock held by caller and conn is valid
+func (n *Network) send() bool {
+	for len(n.sendCache) > 0 {
+		var pkt []byte
+		if len(n.sendCache) > 1024 {
+			pkt, n.sendCache = n.sendCache[0:1024], n.sendCache[1024:]
+		} else {
+			pkt, n.sendCache = n.sendCache, []byte{}
+		}
+		n.conn.SetDeadline(time.Now().Add(n.timeout))
+		nSent, err := n.conn.Write(pkt)
+		if nSent != len(pkt) {
+			n.sendCache = append(pkt, n.sendCache...)
+			return false
+		}
+		if err != nil {
+			n.sendCache = append(pkt, n.sendCache...)
+			return false
+		}
 	}
-	nBytes, err := conn.Write([]byte{b})
-	if err != nil || nBytes != 1 {
-		conn.Close()
-		return false
-	}
-	conn.Close()
 	return true
 }
 
-// Attempts to send a byte of data to localhost at the saved port
+// Same as Push, but doesn't retry and assumes lock is held by caller
+func (n *Network) pushOnce() bool {
+	if n.state == netStateConnected && n.send() {
+		// Used existing connection successful
+		return true
+	}
+	if n.state != netStateIdle {
+		// We're not idle, so reset
+		n.reset(false)
+	}
+	if !n.setupConnection() {
+		// We failed to setup a connection
+		return false
+	}
+	return n.send()
+}
+
+// Attempts to send queued data to NetTargetAddr at the saved port
+// Returns true if success, false otherwise
+func (n *Network) Push() bool {
+	n.lock(false)
+	defer n.unlock()
+	for {
+		if n.pushOnce() {
+			return true
+		}
+		if n.timeout != NetLongTimeout {
+			// Not a blocking call, return false
+			return false
+		}
+	}
+}
+
+// Adds data to the send queue
+func (n *Network) QueueSend(b byte) {
+	n.lock(false)
+	n.sendCache = append(n.sendCache, b)
+	n.unlock()
+}
+
+// Internal version of receive
+// Requires caller to held lock and only tries once
+// Returns received data or false
+func (n *Network) receiveOnce() (byte, bool) {
+	singleByte := make([]byte, 1)
+	if n.state == netStateConnected {
+		// Try receiving now
+		n.conn.SetDeadline(time.Now().Add(n.timeout))
+		nSent, err := n.conn.Read(singleByte)
+		if nSent == 1 && err == nil {
+			return singleByte[0], true
+		}
+	}
+	if n.state != netStateIdle && n.state != netStateListening {
+		n.reset(true)
+	}
+	if n.state != netStateListening && !n.startListening() {
+		return 0, false
+	}
+	timedOut := atomic.Bool{}
+	time.AfterFunc(n.timeout, func() { timedOut.Store(true) })
+	n.unlock()
+	for !timedOut.Load() {
+		n.lock(false)
+		if n.state == netStateIdle {
+			return 0, false
+		}
+		if n.state == netStateConnected {
+			n.conn.SetDeadline(time.Now().Add(n.timeout))
+			nSent, err := n.conn.Read(singleByte)
+			if nSent == 1 && err == nil {
+				return singleByte[0], true
+			}
+			return 0, false
+		}
+		n.unlock()
+		time.Sleep(time.Second / 100)
+	}
+	return 0, false
+}
+
+// Attempts to receive a byte of data from NetListenAddr at the saved port
 // Returns the received byte if successful, 0 otherwise
 func (n *Network) Receive() byte {
-	// Setup Connection
-	listener, err := net.Listen("tcp4", "0.0.0.0:"+n.port)
-	if err != nil {
-		return 0
-	}
-	// Listen Async
-	resultChan := make(chan byte, 1)
-	go func() {
-		conn, err := listener.Accept()
-		if err != nil {
-			resultChan <- 0
-			return
+	n.lock(false)
+	defer n.unlock()
+	for {
+		b, ok := n.receiveOnce()
+		if ok {
+			return b
 		}
-		defer conn.Close()
-		b := make([]byte, 1)
-		nBytes, err := conn.Read(b)
-		if nBytes == 0 || err != nil {
-			resultChan <- 0
-			return
+		if n.timeout != NetLongTimeout {
+			// Not a blocking call, return 0
+			return 0
 		}
-		resultChan <- b[0]
-	}()
-	// Wait on listener or timer
-	select {
-	case b := <-resultChan:
-		listener.Close()
-		return b
-	case <-time.After(n.timeout):
-		listener.Close()
-		return 0
 	}
 }
 
 // Returns network with default values
 func NewNetwork() *Network {
 	return &Network{
-		timeout: 5 * time.Second,
-		port:    ":42000",
+		isLocked:  atomic.Bool{},
+		state:     netStateIdle,
+		timeout:   5 * time.Second,
+		port:      ":42000",
+		listener:  nil,
+		conn:      nil,
+		sendCache: []byte{},
 	}
 }
 

--- a/src/instructions.go
+++ b/src/instructions.go
@@ -203,5 +203,5 @@ func IsValidInstruction(b byte, ext ExtensionCode) bool {
 		b == byte('.') || b == byte(',') || // Base: Write/Read Input
 		b == byte('[') || b == byte(']') || // Base: Conditional Loop
 		(ext&ExtNet == ExtNet) && // Extension: Network
-			(b == byte('?') || b == byte('^') || b == byte('@') || b == byte('*')))
+			(b == byte('?') || b == byte('^') || b == byte('@') || b == byte('*') || b == byte(';')))
 }

--- a/src/instructions_test.go
+++ b/src/instructions_test.go
@@ -75,6 +75,7 @@ func TestIsValidInstruction(t *testing.T) {
 		'@': true,
 		'?': true,
 		'^': true,
+		';': true,
 	}
 
 	for i := 0; i < 256; i++ {

--- a/src/program.go
+++ b/src/program.go
@@ -124,10 +124,15 @@ func (p *Program) RunNext() error {
 		p.Memory.Set(p.Network.Receive())
 		return nil
 	}
-	// Sends the byte at the data pointer to the target if set,
-	// if successful sets the byte at the data pointer to `0`
+	// Queues the byte at the data pointer to be sent
 	if instruction == '^' && extNet {
-		if ok := p.Network.Send(p.Memory.Get()); ok {
+		p.Network.QueueSend(p.Memory.Get())
+		return nil
+	}
+	// Sends the queued data to the target port
+	// Sets the data pointer value to `0` is successful
+	if instruction == ';' && extNet {
+		if ok := p.Network.Push(); ok {
 			p.Memory.Set(0)
 		}
 		return nil

--- a/src/program.go
+++ b/src/program.go
@@ -16,13 +16,13 @@ var (
 )
 
 type Program struct {
-	// Program instructions
-	instructions *Instructions
-	// Program memory
-	memory *Memory
+	// Program Instructions
+	Instructions *Instructions
+	// Program Memory
+	Memory *Memory
 
 	// Network Extension
-	network *Network
+	Network *Network
 
 	// Writer for IO output
 	IOWriter io.Writer
@@ -47,7 +47,7 @@ func (p *Program) Run(limit int) error {
 // Runs the next instruction
 // Returns an error if any
 func (p *Program) RunNext() error {
-	instruction := p.instructions.Pop()
+	instruction := p.Instructions.Pop()
 	if instruction == 0 {
 		return ErrProgramDone
 	}
@@ -56,25 +56,25 @@ func (p *Program) RunNext() error {
 	**/
 	// Increment the data pointer
 	if instruction == '>' {
-		return p.memory.Next()
+		return p.Memory.Next()
 	}
 	// Decrement the data pointer
 	if instruction == '<' {
-		return p.memory.Prev()
+		return p.Memory.Prev()
 	}
 	// Increment (by one) the byte at the data pointer
 	if instruction == '+' {
-		p.memory.Incr()
+		p.Memory.Incr()
 		return nil
 	}
 	// Decrement (by one) the byte at the data pointer
 	if instruction == '-' {
-		p.memory.Decr()
+		p.Memory.Decr()
 		return nil
 	}
 	// Output the value at the data pointer
 	if instruction == '.' {
-		n, err := p.IOWriter.Write([]byte{p.memory.Get()})
+		n, err := p.IOWriter.Write([]byte{p.Memory.Get()})
 		if n != 1 || err != nil {
 			return ErrIoNoOutput
 		}
@@ -87,48 +87,48 @@ func (p *Program) RunNext() error {
 		if n != 1 || err != nil {
 			return ErrIoNoInput
 		}
-		p.memory.Set(b[0])
+		p.Memory.Set(b[0])
 		return nil
 	}
 	// If the data pointer byte is zero, jump to the next corresponding `]`
 	if instruction == '[' {
-		if p.memory.Get() == 0 {
-			p.instructions.JumpForward(']')
+		if p.Memory.Get() == 0 {
+			p.Instructions.JumpForward(']')
 		}
 		return nil
 	}
 	// If the data pointer byte is non-zero, jump to the previous corresponding `[`
 	if instruction == ']' {
-		if p.memory.Get() != 0 {
-			p.instructions.JumpBackward('[')
+		if p.Memory.Get() != 0 {
+			p.Instructions.JumpBackward('[')
 		}
 		return nil
 	}
 	/*
 	* Extension: Network
 	**/
-	extNet := p.instructions.extensions&ExtNet == ExtNet
+	extNet := p.Instructions.extensions&ExtNet == ExtNet
 	// Sets the timeout to the byte at the data pointer times 0.1 seconds
 	if instruction == '*' && extNet {
-		p.network.SetTimeout(p.memory.Get())
+		p.Network.SetTimeout(p.Memory.Get())
 		return nil
 	}
 	// Set the port based on the byte at the data pointer
 	if instruction == '@' && extNet {
-		p.network.SetPort(p.memory.Get())
+		p.Network.SetPort(p.Memory.Get())
 		return nil
 	}
 	// Listen for a message and writes the received value to the byte at the data pointer
 	// On error sets the byte at the data pointer to `0`
 	if instruction == '?' && extNet {
-		p.memory.Set(p.network.Receive())
+		p.Memory.Set(p.Network.Receive())
 		return nil
 	}
 	// Sends the byte at the data pointer to the target if set,
 	// if successful sets the byte at the data pointer to `0`
 	if instruction == '^' && extNet {
-		if ok := p.network.Send(p.memory.Get()); ok {
-			p.memory.Set(0)
+		if ok := p.Network.Send(p.Memory.Get()); ok {
+			p.Memory.Set(0)
 		}
 		return nil
 	}
@@ -138,8 +138,8 @@ func (p *Program) RunNext() error {
 
 // Rests memory and the program counter
 func (p *Program) Reset() {
-	p.instructions.Reset()
-	p.memory.Reset()
+	p.Instructions.Reset()
+	p.Memory.Reset()
 }
 
 // Loads a new program (without resetting memory)
@@ -149,18 +149,18 @@ func (p *Program) LoadProgram(r io.Reader) error {
 		return err
 	}
 
-	p.instructions = inst
+	p.Instructions = inst
 	return nil
 }
 
 // Returns true if the given extension is enabled
 func (p Program) HasExtensions(ec ExtensionCode) bool {
-	return p.instructions.extensions&ec == ec
+	return p.Instructions.extensions&ec == ec
 }
 
 // Returns the parsed instructions
 func (p Program) GetInstructions() []byte {
-	return p.instructions.instruction
+	return p.Instructions.instruction
 }
 
 // Returns a new empty program
@@ -171,9 +171,9 @@ func NewProgram(r io.Reader) (Program, error) {
 	}
 
 	return Program{
-		instructions: inst,
-		memory:       NewMemory(),
-		network:      NewNetwork(),
+		Instructions: inst,
+		Memory:       NewMemory(),
+		Network:      NewNetwork(),
 		IOWriter:     os.Stdout,
 		IOReader:     os.Stdin,
 	}, nil

--- a/src/program_test.go
+++ b/src/program_test.go
@@ -16,22 +16,22 @@ func TestProgram(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to load program: %v", err)
 	}
-	if len(p.instructions.instruction) != 6 {
+	if len(p.Instructions.instruction) != 6 {
 		t.Fatal("Failed to load instructions corretly in a new program")
 	}
-	p.memory.Set(11)
-	p.memory.p = 2
-	p.memory.Set(17)
-	p.instructions.pc = 3
+	p.Memory.Set(11)
+	p.Memory.p = 2
+	p.Memory.Set(17)
+	p.Instructions.pc = 3
 	p.Reset()
-	if p.memory.p != 0 || p.instructions.pc != 0 || len(p.memory.Bytes()) != 0 {
-		t.Fatalf("Failed to reset program: %d, %d, %+d", p.memory.p, p.instructions.pc, p.memory.Bytes())
+	if p.Memory.p != 0 || p.Instructions.pc != 0 || len(p.Memory.Bytes()) != 0 {
+		t.Fatalf("Failed to reset program: %d, %d, %+d", p.Memory.p, p.Instructions.pc, p.Memory.Bytes())
 	}
 	if p.HasExtensions(ExtNet) {
 		t.Fatal("Incorrectly reported Network Extension as enabled")
 	}
 	p.LoadProgram(strings.NewReader("tl:neet"))
-	if len(p.instructions.instruction) != 0 {
+	if len(p.Instructions.instruction) != 0 {
 		t.Fatal("Failed to load an empty program")
 	}
 	if p.HasExtensions(ExtNet) {
@@ -48,15 +48,15 @@ func TestRunNext(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to load test program: %v", err)
 		}
-		t.Logf("Parsed %s", string(p.instructions.instruction))
+		t.Logf("Parsed %s", string(p.Instructions.instruction))
 		if err = p.Run(11); err != ErrExecutionLimit {
 			t.Fatalf("Expected ErrExecutionLimit on Run, instead got %v", err)
 		}
 		if err = p.RunNext(); err != ErrProgramDone {
 			t.Fatalf("Expected ErrProgramDone on RunNext, instead got %v", err)
 		}
-		t.Logf("PC: %d, MP: %d", p.instructions.pc, p.memory.p)
-		actualMem := p.memory.Bytes()
+		t.Logf("PC: %d, MP: %d", p.Instructions.pc, p.Memory.p)
+		actualMem := p.Memory.Bytes()
 		expectedMem := []byte{1, 2, 3}
 		if !bytes.Equal(actualMem, expectedMem) {
 			t.Fatalf("Expected %+d, but memory is %+d", expectedMem, actualMem)
@@ -67,12 +67,12 @@ func TestRunNext(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to load test program: %v", err)
 		}
-		t.Logf("Parsed %s", string(p.instructions.instruction))
+		t.Logf("Parsed %s", string(p.Instructions.instruction))
 		if err = p.Run(2 + 5*256 + 4 + 1); err != nil {
 			t.Fatalf("Expected no error on Run, instead got %v", err)
 		}
-		t.Logf("PC: %d, MP: %d", p.instructions.pc, p.memory.p)
-		actualMem := p.memory.Bytes()
+		t.Logf("PC: %d, MP: %d", p.Instructions.pc, p.Memory.p)
+		actualMem := p.Memory.Bytes()
 		expectedMem := []byte{0, 255}
 		if !bytes.Equal(actualMem, expectedMem) {
 			t.Fatalf("Expected %+d, but memory is %s", expectedMem, actualMem)
@@ -83,7 +83,7 @@ func TestRunNext(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to load test program: %v", err)
 		}
-		t.Logf("Parsed %s", string(p.instructions.instruction))
+		t.Logf("Parsed %s", string(p.Instructions.instruction))
 		// Custom writer/reader
 		p.IOReader = strings.NewReader("!")
 		outputBuffer := bytes.NewBuffer(make([]byte, 0, 256))
@@ -92,8 +92,8 @@ func TestRunNext(t *testing.T) {
 		if err = p.Run(1 + 3 + 3*255 + 2 + 1); err != nil {
 			t.Fatalf("Expected no error on Run, instead got %v", err)
 		}
-		t.Logf("PC: %d, MP: %d", p.instructions.pc, p.memory.p)
-		actualMem := p.memory.Bytes()
+		t.Logf("PC: %d, MP: %d", p.Instructions.pc, p.Memory.p)
+		actualMem := p.Memory.Bytes()
 		expectedMem := []byte{0, '!'}
 		if !bytes.Equal(actualMem, expectedMem) {
 			t.Fatalf("Expected %+d, but memory is %+d", expectedMem, actualMem)
@@ -112,34 +112,34 @@ func TestRunNext(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to load test program: %v", err)
 		}
-		t.Logf("Parsed %q", string(p.instructions.instruction))
+		t.Logf("Parsed %q", string(p.Instructions.instruction))
 		for i := 0; i < 3; i++ {
 			if err := p.RunNext(); err != nil {
 				t.Fatalf("Expected no error, instead got %v for %d's instruction", err, i)
 			}
 		}
-		if p.network.timeout != time.Millisecond*200 {
-			t.Fatalf("The timeout wasn't set correctly: %q", p.network.timeout.String())
+		if p.Network.timeout != time.Millisecond*200 {
+			t.Fatalf("The timeout wasn't set correctly: %q", p.Network.timeout.String())
 		}
 		for i := 0; i < 2; i++ {
 			if err := p.RunNext(); err != nil {
 				t.Fatalf("Expected no error, instead got %v for %d's instruction", err, i)
 			}
 		}
-		if p.network.port != "42001" {
-			t.Fatalf("The port wasn't set correctly: %q", p.network.port)
+		if p.Network.port != "42001" {
+			t.Fatalf("The port wasn't set correctly: %q", p.Network.port)
 		}
 		if err := p.RunNext(); err != nil {
 			t.Fatalf("Expected no error, instead got %v for last instruction", err)
 		}
-		if p.memory.Get() != 1 {
-			t.Fatalf("Expected the send to fail and leave a non zero value in memory, instead got %d", p.memory.Get())
+		if p.Memory.Get() != 1 {
+			t.Fatalf("Expected the send to fail and leave a non zero value in memory, instead got %d", p.Memory.Get())
 		}
 		if err := p.RunNext(); err != nil {
 			t.Fatalf("Expected no error, instead got %v for last instruction", err)
 		}
-		if p.memory.Get() != 0 {
-			t.Fatalf("Expected the receive to fail and leave a zero value in memory, instead got %d", p.memory.Get())
+		if p.Memory.Get() != 0 {
+			t.Fatalf("Expected the receive to fail and leave a zero value in memory, instead got %d", p.Memory.Get())
 		}
 		if err := p.RunNext(); err != ErrProgramDone {
 			t.Fatalf("Expected ErrProgramDone, instead got %v for last instruction", err)


### PR DESCRIPTION
- Keep connections alive
- `^` now queues the data for send, then `;` flushes the send queue